### PR TITLE
fix_resume

### DIFF
--- a/lib/countdown_progress_indicator.dart
+++ b/lib/countdown_progress_indicator.dart
@@ -170,12 +170,7 @@ class CountDownController {
 
   /// Resumes countdown time
   void resume() {
-    final currentPosition = _state._animation.value;
-    _state._animation = Tween<double>(
-      begin: currentPosition,
-      end: _state.widget.duration.toDouble(),
-    ).animate(_state._animationController);
-    _state._animationController.forward(from: 0);
+    _state._animationController.forward();
   }
 
   /// Starts countdown timer


### PR DESCRIPTION
Thanks for the great package.

There was a bug in "resume()" and I have fixed it, please check it out.

Before the fix, "resume()" would always start with the "Duration" of the initialization.

By applying this fix, the above bug will be removed and "resume()" will restart with the correct number of seconds.